### PR TITLE
Fixing unit tests for exercise 8

### DIFF
--- a/excercise8/index.test.js
+++ b/excercise8/index.test.js
@@ -16,25 +16,25 @@ describe("task", () => {
 
 describe("failedTask", () => {
   test("rejects", () => {
-    return expect(failedTask.run()).rejects;
+    return expect(failedTask.run()).rejects.toEqual('OMG');
   });
 });
 
 describe("mappedTask", () => {
   test("resolves with 8", () => {
-    return expect(task.run()).resolves.toBe(8);
+    return expect(mappedTask.run()).resolves.toBe(8);
   });
 });
 
 describe("getRandom", () => {
   test("generated a random", () => {
-    return expect(task.run()).resolves;
+    return expect(getRandom.run()).resolves.toEqual(expect.any(Number));
   });
 });
 
 describe("fetchPubliIp", () => {
   test("fetches the public ip", () => {
-    return expect(task.run()).resolves.toMatch(/\d{3}\.\d{3}\.\d{3}\.\d/);
+    return expect(fetchPubliIp.run()).resolves.toMatch(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/);
   });
 });
 


### PR DESCRIPTION
Fixed the following: 
The failedTask - rejects test is not checking for the returned value.
The mappedTask -resolved with 8 test is referring to a different variable.
The getRandom test should is referring to a different variable.